### PR TITLE
use relative include instead of <> in `hffix.hpp`

### DIFF
--- a/include/hffix.hpp
+++ b/include/hffix.hpp
@@ -35,7 +35,7 @@ or implied, of T3 IP, LLC.
 #ifndef HFFIX_HPP
 #define HFFIX_HPP
 
-#include <hffix_fields.hpp> // for field and message tag names and properties. Needed for length_fields[].
+#include "hffix_fields.hpp" // for field and message tag names and properties. Needed for length_fields[].
 #include <cstring>          // for memcpy
 #include <string>           //
 #include <algorithm>        // for is_tag_a_data_length


### PR DESCRIPTION
I don't want to place these two header files in my include directories; I'd rather just add them to my library with CMake. This requires the relative importing of `hffix_fields.hpp`.

Let me know if there's a better way to do this.