### PR TITLE
fixed stack-use-after-scope when assigning message_reader

### DIFF
--- a/include/hffix.hpp
+++ b/include/hffix.hpp
@@ -1953,16 +1953,36 @@ public:
         is_valid_(true) {
         init();
     }
+
     /*!
      * \brief Copy constructor. The hffix::message_reader is immutable, so copying it is fine.
      */
     message_reader(message_reader const& that) :
         buffer_(that.buffer_),
         buffer_end_(that.buffer_end_),
-        begin_(that.begin_),
-        end_(that.end_),
+        begin_(*this, 0),
+        end_(*this, 0),
         is_complete_(that.is_complete_),
         is_valid_(that.is_valid_) {
+        init();
+    }
+
+    /*!
+     * \brief Assignment operator.
+     *
+     * This can't be the default assignment operator because begin_ and end_ are const_iterators which
+     * point back to 'this'. If we copy them as is they will point back to the previous 'that'.
+    */
+    message_reader& operator = (const message_reader& that)
+    {
+        buffer_= that.buffer_;
+        buffer_end_ = that.buffer_end_;
+        begin_ = const_iterator(*this, 0);
+        end_ = const_iterator(*this, 0);
+        is_complete_ = that.is_complete_;
+        is_valid_ = that.is_valid_;
+        init();
+        return *this;
     }
 
     /*!

--- a/test/src/unit_tests.cpp
+++ b/test/src/unit_tests.cpp
@@ -13,6 +13,7 @@ using namespace hffix;
 #include <chrono>
 #include <iomanip>
 #endif
+#include <iterator>
 
 BOOST_AUTO_TEST_CASE(basic)
 {
@@ -256,6 +257,30 @@ BOOST_AUTO_TEST_CASE(data_length)
     BOOST_REQUIRE(found);
     BOOST_REQUIRE(i != reader.end());
     BOOST_CHECK_EQUAL(i->value().as_string(), datum);
+}
+
+BOOST_AUTO_TEST_CASE(iterating)
+{
+    char b[1024];
+    char* ptr = b;
+    unsigned num = 0;
+    for(size_t i = 0; i < 10; i++ ) {
+      message_writer w(ptr, 1024 - (ptr - b));
+      w.push_back_header("FIX.4.2");
+      w.push_back_string(tag::MsgType, "A");
+      w.push_back_trailer();
+      ptr += w.message_size();
+    }
+
+    for (message_reader reader(b);
+        reader.is_complete();
+        reader = reader.next_message_reader()) {
+        if(reader.is_complete() && reader.is_valid()) {
+          BOOST_CHECK_EQUAL(std::distance(reader.begin(), reader.end()), 1);
+          num++;
+        }
+    }
+    BOOST_CHECK_EQUAL(num, 10u);
 }
 
 #if __cplusplus >= 201103L


### PR DESCRIPTION
Thank you for the great work on this library! Getting started with it has been effortless!

I've hit the same bug as encountered in  https://github.com/jamesdbrock/hffix/issues/27 and solved it in the easiest way possible - by making the copy constructor and assignment operator 're-init' and thus use the const_iterator correctly. In doing so I realize that this is of course less efficient ( init() does do work ) but this fix has the benefit of being correct. Also it doesn't change the behaviour.

There's a unit test in here, which replicates the problem if you run under asan, and shows that the problem is now resolved.

Please let me know what you think.