### PR TITLE
Fix for std::basic_string_view<char>::const_iterator not being convertible to const char * in Windows (issue #43)

### DIFF
--- a/include/hffix.hpp
+++ b/include/hffix.hpp
@@ -900,7 +900,7 @@ public:
     \throw std::out_of_range When the remaining buffer size is too small.
     */
     void push_back_string(int tag, std::string_view s) {
-        push_back_string(tag, s.begin(), s.end());
+        push_back_string(tag, s.data(), s.data() + s.length());
     }
 #endif
 


### PR DESCRIPTION
Fix for `std::basic_string_view<char>::const_iterator` not being convertible to `const char *` in Windows (issue #43)
